### PR TITLE
Allow image decoding requests to be cancelled

### DIFF
--- a/app/src/main/java/com/example/finnur/finnursphotopicker/DecoderServiceHost.java
+++ b/app/src/main/java/com/example/finnur/finnursphotopicker/DecoderServiceHost.java
@@ -159,6 +159,10 @@ public class DecoderServiceHost {
         }
     }
 
+    public void cancelDecodeImage(String filePath) {
+        // TODO
+    }
+
     static class IncomingHandler extends Handler {
         private final WeakReference<DecoderServiceHost> mHost;
 

--- a/app/src/main/java/com/example/finnur/finnursphotopicker/PickerCategoryView.java
+++ b/app/src/main/java/com/example/finnur/finnursphotopicker/PickerCategoryView.java
@@ -36,7 +36,8 @@ import java.util.List;
 
 public class PickerCategoryView extends RelativeLayout
         implements FileEnumWorkerTask.FilesEnumeratedCallback,
-                DecoderServiceHost.ServiceReadyCallback {
+                DecoderServiceHost.ServiceReadyCallback,
+                RecyclerView.RecyclerListener {
     private Context mContext;
     private PickerAdapter mPickerAdapter;
     private List<PickerBitmap> mPickerBitmaps;
@@ -199,6 +200,7 @@ public class PickerCategoryView extends RelativeLayout
             OnPhotoPickerListener listener, boolean multiSelection, int width) {
         mRecyclerView = (RecyclerView) findViewById(R.id.recycler_view);
         mRecyclerView.addItemDecoration(new RecyclerViewItemDecoration());
+        mRecyclerView.setRecyclerListener(this);
         mSelectionDelegate = selectionDelegate;
         mMultiSelection = multiSelection;
         mPath = path;
@@ -283,5 +285,17 @@ public class PickerCategoryView extends RelativeLayout
 
         mWorkerTask = new FileEnumWorkerTask(this);
         mWorkerTask.execute(path);
+    }
+
+    public void onViewRecycled(RecyclerView.ViewHolder holder) {
+        if (!useDecoderService()) {
+            return;
+        }
+
+        PickerBitmapViewHolder bitmapHolder = (PickerBitmapViewHolder) holder;
+        String filePath = bitmapHolder.getFilePath();
+        if (filePath != null) {
+            getDecoderServiceHost().cancelDecodeImage(filePath);
+        }
     }
 }


### PR DESCRIPTION
Something I noticed while using the prototype: if I scroll the view too rapidly, the DecoderService still attempts to load thumbnails even once they've scrolled past. If you swipe up quickly, this can mean a really long delay as older thumbnails are loaded, generated, then instantly discarded.

This pull is an attempt to make decodeImage requests cancellable. When the RecyclerView recycles a PickerBitmapView, it's decodeImage request gets cancelled if it hasn't yet begun. It does so by making all decodeImage requests sequential, adding them to a queue, then removing them from the queue if they haven't been dispatched yet.

I don't know enough about Messengers/Handlers/Services to know if they can handle requests in parallel. If so, this could actually hurt performance, but in my limited testing, it did not appear appear so. If its possible to cancel Messages with Messengers/Services, that might be the better approach, but I couldn't find any documentation about how to do so.

Feel free to make use of this if you like.
