### PR TITLE
Added MIME- and extension-based file filtering

### DIFF
--- a/app/src/main/java/com/example/finnur/finnursphotopicker/AcceptFileFilter.java
+++ b/app/src/main/java/com/example/finnur/finnursphotopicker/AcceptFileFilter.java
@@ -1,0 +1,152 @@
+package com.example.finnur.finnursphotopicker;
+
+import android.support.annotation.NonNull;
+import android.webkit.MimeTypeMap;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.function.Predicate;
+
+
+public abstract class AcceptFileFilter {
+    private static AcceptFileFilter mDefaultSingleton = null;
+
+    @NonNull
+    public static AcceptFileFilter getDefault() {
+        if (mDefaultSingleton == null) {
+            mDefaultSingleton = new DefaultAcceptFileFilter();
+        }
+        return mDefaultSingleton;
+    }
+
+    @NonNull
+    public static AcceptFileFilter forAttr(@NonNull String acceptAttr) {
+        return new AttrAcceptFileFilter(acceptAttr);
+    }
+
+    public abstract boolean test(@NonNull File file);
+
+    public abstract boolean acceptsImages();
+
+    public abstract boolean acceptsVideos();
+
+    public abstract boolean acceptsOther();
+}
+
+
+class DefaultAcceptFileFilter extends AcceptFileFilter {
+
+    @Override
+    public boolean test(@NonNull File file) {
+        return true;
+    }
+
+    @Override
+    public boolean acceptsImages() {
+        return true;
+    }
+
+    @Override
+    public boolean acceptsVideos() {
+        return true;
+    }
+
+    @Override
+    public boolean acceptsOther() {
+        return true;
+    }
+}
+
+
+class AttrAcceptFileFilter extends AcceptFileFilter {
+    private static final String IMAGE_SUPERTYPE = "image";
+    private static final String VIDEO_SUPERTYPE = "video";
+
+    private HashSet<String> mExtensions = new HashSet<>();
+    private HashSet<String> mMimeTypes = new HashSet<>();
+    private HashSet<String> mMimeSupertypes = new HashSet<>();
+    private MimeTypeMap mMimeTypeMap;
+
+
+    public AttrAcceptFileFilter(@NonNull String acceptAttr) {
+        for (String field : acceptAttr.toLowerCase().split(",")) {
+            field = field.trim();
+            if (field.startsWith(".")) {
+                mExtensions.add(field.substring(1));
+            } else if (field.endsWith("/*")) {
+                mMimeSupertypes.add(field.substring(0, field.length()-2));
+            } else if (field.contains("/")) {
+                mMimeTypes.add(field);
+            } else {
+                // Throw exception?
+            }
+        }
+
+        mMimeTypeMap = MimeTypeMap.getSingleton();
+    }
+
+    @Override
+    public boolean test(@NonNull File file) {
+        String uri = file.toURI().toString();
+        String ext = MimeTypeMap.getFileExtensionFromUrl(uri).toLowerCase();
+        if (mExtensions.contains(ext)) {
+            return true;
+        }
+
+        String mimeType = getMimeTypeFromExtension(ext);
+        if (mimeType != null) {
+            if (mMimeTypes.contains(mimeType)) {
+                return true;
+            }
+            if (mMimeSupertypes.contains( getMimeSupertype(mimeType) )) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean acceptsImages() {
+        return getAcceptedSupertypes().contains(IMAGE_SUPERTYPE);
+    }
+
+    @Override
+    public boolean acceptsVideos() {
+        return getAcceptedSupertypes().contains(VIDEO_SUPERTYPE);
+    }
+
+    @Override
+    public boolean acceptsOther() {
+        HashSet<String> supertypes = getAcceptedSupertypes();
+        supertypes.remove(IMAGE_SUPERTYPE);
+        supertypes.remove(VIDEO_SUPERTYPE);
+        return !supertypes.isEmpty();
+    }
+
+    private HashSet<String> getAcceptedSupertypes() {
+        HashSet<String> supertypes = new HashSet<>();
+        supertypes.addAll(mMimeSupertypes);
+        for (String mimeType : mMimeTypes) {
+            supertypes.add( getMimeSupertype(mimeType) );
+        }
+        for (String ext : mExtensions) {
+            String mimeType = getMimeTypeFromExtension(ext);
+            if (mimeType != null) {
+                supertypes.add( getMimeSupertype(mimeType) );
+            }
+        }
+        return supertypes;
+    }
+
+    private String getMimeTypeFromExtension(@NonNull String ext) {
+        String mimeType = mMimeTypeMap.getMimeTypeFromExtension(ext);
+        return (mimeType != null) ? mimeType.toLowerCase() : null;
+    }
+
+    @NonNull
+    private String getMimeSupertype(@NonNull String mimeType) {
+        return mimeType.split("/", 2)[0];
+    }
+}

--- a/app/src/main/java/com/example/finnur/finnursphotopicker/AcceptFileFilter.java
+++ b/app/src/main/java/com/example/finnur/finnursphotopicker/AcceptFileFilter.java
@@ -4,12 +4,13 @@ import android.support.annotation.NonNull;
 import android.webkit.MimeTypeMap;
 
 import java.io.File;
+import java.io.FileFilter;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.function.Predicate;
 
 
-public abstract class AcceptFileFilter {
+public abstract class AcceptFileFilter implements FileFilter {
     private static AcceptFileFilter mDefaultSingleton = null;
 
     @NonNull
@@ -25,7 +26,7 @@ public abstract class AcceptFileFilter {
         return new AttrAcceptFileFilter(acceptAttr);
     }
 
-    public abstract boolean test(@NonNull File file);
+    public abstract boolean accept(@NonNull File file);
 
     public abstract boolean acceptsImages();
 
@@ -38,7 +39,7 @@ public abstract class AcceptFileFilter {
 class DefaultAcceptFileFilter extends AcceptFileFilter {
 
     @Override
-    public boolean test(@NonNull File file) {
+    public boolean accept(@NonNull File file) {
         return true;
     }
 
@@ -87,7 +88,11 @@ class AttrAcceptFileFilter extends AcceptFileFilter {
     }
 
     @Override
-    public boolean test(@NonNull File file) {
+    public boolean accept(@NonNull File file) {
+        if (file.isDirectory()) {
+            return true;
+        }
+
         String uri = file.toURI().toString();
         String ext = MimeTypeMap.getFileExtensionFromUrl(uri).toLowerCase();
         if (mExtensions.contains(ext)) {

--- a/app/src/main/java/com/example/finnur/finnursphotopicker/FileEnumWorkerTask.java
+++ b/app/src/main/java/com/example/finnur/finnursphotopicker/FileEnumWorkerTask.java
@@ -23,9 +23,15 @@ class FileEnumWorkerTask extends AsyncTask<String, Void, List<PickerBitmap>> {
     }
 
     private FilesEnumeratedCallback mCallback;
+    private AcceptFileFilter mFilter;
 
     public FileEnumWorkerTask(FilesEnumeratedCallback callback) {
+        this(callback, AcceptFileFilter.getDefault());
+    }
+
+    public FileEnumWorkerTask(FilesEnumeratedCallback callback, AcceptFileFilter filter) {
         mCallback = callback;
+        mFilter = filter;
     }
 
     // Enumerate files in background.
@@ -58,7 +64,10 @@ class FileEnumWorkerTask extends AsyncTask<String, Void, List<PickerBitmap>> {
                 }
 
                 File file = files[i];
-                
+                if (!mFilter.test(file)) {
+                    continue;
+                }
+
                 //Log.e("chromium", "FileName:" + file.getPath().toString() + "/" + file.getName() +
                 //                  " size: " + file.length());
                 pickerBitmaps.add(

--- a/app/src/main/java/com/example/finnur/finnursphotopicker/FileEnumWorkerTask.java
+++ b/app/src/main/java/com/example/finnur/finnursphotopicker/FileEnumWorkerTask.java
@@ -53,19 +53,14 @@ class FileEnumWorkerTask extends AsyncTask<String, Void, List<PickerBitmap>> {
         for (int path = 0; path < paths.length; ++path) {
             String filePath = Environment.getExternalStorageDirectory().toString() + paths[path];
             File directory = new File(filePath);
-            File[] files = directory.listFiles();
+            File[] files = directory.listFiles(mFilter);
             if (files == null) {
                 continue;
             }
 
-            for (int i = 0; i < files.length; ++i) {
+            for (File file : files) {
                 if (isCancelled()) {
                     return null;
-                }
-
-                File file = files[i];
-                if (!mFilter.test(file)) {
-                    continue;
                 }
 
                 //Log.e("chromium", "FileName:" + file.getPath().toString() + "/" + file.getName() +

--- a/app/src/main/java/com/example/finnur/finnursphotopicker/PickerCategoryView.java
+++ b/app/src/main/java/com/example/finnur/finnursphotopicker/PickerCategoryView.java
@@ -280,7 +280,7 @@ public class PickerCategoryView extends RelativeLayout
             mWorkerTask.cancel(true);
         }
 
-        mWorkerTask = new FileEnumWorkerTask(this);
+        mWorkerTask = new FileEnumWorkerTask(this, AcceptFileFilter.forAttr("image/*,video/*"));
         mWorkerTask.execute();
     }
 


### PR DESCRIPTION
- Added AcceptFileFilter, which encapsulates a filter string passed in the accept attribute.
- Added mFilter to FileEnumWorkerTask, which filters out files as they are enumerated.
- Made "image/*,video/*" the default filter for the prototype.